### PR TITLE
cmd: add checks for length of args

### DIFF
--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/vanilla-os/almost/core"
 )
 
@@ -56,11 +57,15 @@ func overlay(cmd *cobra.Command, args []string) error {
 
 	switch args[0] {
 	case "new":
+		if len(args) != 2 {overlayUsage()}
 		return core.OverlayAdd(args[1], false, verbose)
 	case "commit":
+		if len(args) != 2 {overlayUsage()}
 		return core.OverlayRemove(args[1], true, verbose)
 	case "discard":
+		if len(args) != 2 {overlayUsage()}
 		return core.OverlayRemove(args[1], false, verbose)
+		
 	case "list":
 		return listOverlays()
 	default:

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -60,13 +60,13 @@ func overlay(cmd *cobra.Command, args []string) error {
 
 	switch args[0] {
 	case "new":
-		if len(args) != 2 {fmt.Print(USAGE_MSG); return nil}
+		if len(args) != 2 {return fmt.Errorf("missing command")}
 		return core.OverlayAdd(args[1], false, verbose)
 	case "commit":
-		if len(args) != 2 {fmt.Print(USAGE_MSG); return nil}
+		if len(args) != 2 {return fmt.Errorf("missing command")}
 		return core.OverlayRemove(args[1], true, verbose)
 	case "discard":
-		if len(args) != 2 {fmt.Print(USAGE_MSG); return nil}
+		if len(args) != 2 {return fmt.Errorf("missing command")}
 		return core.OverlayRemove(args[1], false, verbose)
 		
 	case "list":

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -8,8 +8,7 @@ import (
 	"github.com/vanilla-os/almost/core"
 )
 
-func overlayUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
+const USAGE_MSG=`Description: 
 Overlay a directory to make it mutable and being able to edit its contents without modifying the originals
 
 Usage:
@@ -20,16 +19,20 @@ Options:
 	--verbose/-v		enable verbose output
 	
 Commands:
-	new [directory]		overlay a directory
-	commit			commit the changes
-	discard			discard the changes
-	list			list the active overlays
+	new [directory]			Overlay a directory
+	commit [directory]		Commit the changes
+	discard [directory]		Discard the changes
+	list					List the active overlays
 
 Examples:
-	almost overlay new /etc/cute-path
-	almost overlay commit
-	almost overlay discard
-`)
+	# almost overlay new /etc/cute-path
+	# almost overlay commit /etc/cute-path
+	# almost overlay discard /etc/cute-path
+	# almost overlay list
+`
+
+func overlayUsage(*cobra.Command) error {
+	fmt.Print(USAGE_MSG)
 	return nil
 }
 
@@ -57,13 +60,13 @@ func overlay(cmd *cobra.Command, args []string) error {
 
 	switch args[0] {
 	case "new":
-		if len(args) != 2 {overlayUsage()}
+		if len(args) != 2 {fmt.Print(USAGE_MSG); return nil}
 		return core.OverlayAdd(args[1], false, verbose)
 	case "commit":
-		if len(args) != 2 {overlayUsage()}
+		if len(args) != 2 {fmt.Print(USAGE_MSG); return nil}
 		return core.OverlayRemove(args[1], true, verbose)
 	case "discard":
-		if len(args) != 2 {overlayUsage()}
+		if len(args) != 2 {fmt.Print(USAGE_MSG); return nil}
 		return core.OverlayRemove(args[1], false, verbose)
 		
 	case "list":

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -8,31 +8,28 @@ import (
 	"github.com/vanilla-os/almost/core"
 )
 
-const USAGE_MSG=`Description: 
-Overlay a directory to make it mutable and being able to edit its contents without modifying the originals
-
-Usage:
-overlay [options] [command] [directory]
-
-Options:
-	--help/-h		show this message
-	--verbose/-v		enable verbose output
-	
-Commands:
-	new [directory]			Overlay a directory
-	commit [directory]		Commit the changes
-	discard [directory]		Discard the changes
-	list					List the active overlays
-
-Examples:
-	# almost overlay new /etc/cute-path
-	# almost overlay commit /etc/cute-path
-	# almost overlay discard /etc/cute-path
-	# almost overlay list
-`
-
 func overlayUsage(*cobra.Command) error {
-	fmt.Print(USAGE_MSG)
+	fmt.Print(`Description: 
+		Overlay a directory to make it mutable and being able to edit its contents without modifying the originals
+		
+		Usage:
+		overlay [options] [command] [directory]
+		
+		Options:
+			--help/-h		show this message
+			--verbose/-v		enable verbose output
+			
+		Commands:
+			new [directory]			Overlay a directory
+			commit [directory]		Commit the changes
+			discard [directory]		Discard the changes
+			list					List the active overlays
+		
+		Examples:
+			# almost overlay new /etc/cute-path
+			# almost overlay commit /etc/cute-path
+			# almost overlay discard /etc/cute-path
+			# almost overlay list`)
 	return nil
 }
 

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -26,10 +26,10 @@ func overlayUsage(*cobra.Command) error {
 			list					List the active overlays
 		
 		Examples:
-			# almost overlay new /etc/cute-path
-			# almost overlay commit /etc/cute-path
-			# almost overlay discard /etc/cute-path
-			# almost overlay list`)
+			almost overlay new /etc/cute-path
+			almost overlay commit /etc/cute-path
+			almost overlay discard /etc/cute-path
+			almost overlay list`)
 	return nil
 }
 


### PR DESCRIPTION
Before this PR the user would get something like
```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/vanilla-os/almost/cmd.overlay(0xc000168780?, {0xc0000535f0, 0x1, 0x1?})
    github.com/vanilla-os/almost/cmd/overlay.go:63 +0x1e5
github.com/spf13/cobra.(*Command).execute(0xc000168780, {0xc0000535b0, 0x1, 0x1})
    github.com/spf13/cobra/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0xc000005900)
    github.com/spf13/cobra/command.go:990 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
    github.com/spf13/cobra/command.go:918
main.main()
    github.com/vanilla-os/almost/main.go:51 +0x2cf
```
When running `sudo almost overlay discard`.

If this PR gets merged the user will get something like this instead:
```
Error: missing command
Description: 
Overlay a directory to make it mutable and being able to edit its contents without modifying the originals

Usage:
overlay [options] [command] [directory]

Options:
        --help/-h               show this message
        --verbose/-v            enable verbose output

Commands:
        new [directory]                 Overlay a directory
        commit [directory]              Commit the changes
        discard [directory]             Discard the changes
        list                                    List the active overlays

Examples:
        # almost overlay new /etc/cute-path
        # almost overlay commit /etc/cute-path
        # almost overlay discard /etc/cute-path
        # almost overlay list
```

This was mostly made to not have cryptic error messages and also apply consistency with other subcommands of `almost` like `almost config set`.